### PR TITLE
Add DigitalCredentials handling impl. example.

### DIFF
--- a/document-manager/build.gradle.kts
+++ b/document-manager/build.gradle.kts
@@ -107,6 +107,8 @@ dependencies {
         exclude(group = "org.bouncycastle")
         exclude(group = "io.ktor")
     }
+    api(libs.multipaz.models)
+    api(libs.multipaz.doctypes)
 
     implementation(libs.kotlinx.datetime)
     implementation(libs.kotlinx.io.core)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ kotlinx-serialization-json = "1.7.3"
 kotlinx-coroutines = "1.9.0"
 mavenPublish = "0.33.0"
 mockk = "1.14.4"
-multipaz = "0.92.0"
+multipaz = "0.93.0"
 sonarqube = "6.2.0.5505"
 eudi-sd-jwt-vc-kt = "0.10.0"
 nimbus = "9.47"
@@ -42,6 +42,8 @@ ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negoti
 ktor-client-serialization = { module = "io.ktor:ktor-client-serialization", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 multipaz = { module = "org.multipaz:multipaz", version.ref = "multipaz" }
+multipaz-models = { module = "org.multipaz:multipaz-models", version.ref = "multipaz" }
+multipaz-doctypes = { module = "org.multipaz:multipaz-doctypes", version.ref = "multipaz" }
 
 [plugins]
 android-library = { id = "com.android.library", version.ref = "agp" }


### PR DESCRIPTION
The DocumentManagerImpl Builder was updated to demonstrate the possible setup of Digital Credentials support within the DocumentManagerImpl init constructor to facilitate the setup during the Wallet application initialization. However, for the real implementation the dependency graph can be used to supply actual document types supported by the Wallet app or they could be passes as a parameter to a public method of the the DocumentManager or its builder.

- The multipaz dependency version bumped to 0.93 to support Digital Credentials.
- The Clock replaced with kotlin.time.Clock as it's shown as deprecation with error.

- Unit tests passing.