### PR TITLE
Fix "No key with given alias" exception in dcapi 

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ file.
 ```kotlin
 dependencies {
     // EUDI Wallet Documents Manager library
-  implementation("eu.europa.ec.eudi:eudi-lib-android-wallet-document-manager:0.17.1-SNAPSHOT")
+  implementation("eu.europa.ec.eudi:eudi-lib-android-wallet-document-manager:0.18.0-SNAPSHOT")
 
     // Optional: Use the multipaz-android library if you want to use the implementations for Storage and SecureArea
     // for Android devices, provided by the OpenWallet Foundation

--- a/document-manager/src/main/java/eu/europa/ec/eudi/wallet/document/IssuedDocument.kt
+++ b/document-manager/src/main/java/eu/europa/ec/eudi/wallet/document/IssuedDocument.kt
@@ -131,7 +131,13 @@ class IssuedDocument(
     suspend fun getCredentials(): List<SecureAreaBoundCredential> {
         return baseDocument.getCertifiedCredentials()
             .filterIsInstance<SecureAreaBoundCredential>()
-            .filterNot { it.secureArea.getKeyInvalidated(it.alias) }
+            .filterNot {
+                try {
+                    it.secureArea.getKeyInvalidated(it.alias)
+                } catch (_: IllegalArgumentException) {
+                    true // key no longer exists — treat as invalidated
+                }
+            }
             .filter { it.domain == documentManagerId }
             .filter {
                 when (credentialPolicy) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -41,7 +41,7 @@ android.nonTransitiveRClass=true
 systemProp.sonar.host.url=https://sonarcloud.io
 systemProp.sonar.gradle.skipCompile=true
 
-VERSION_NAME=0.17.1-SNAPSHOT
+VERSION_NAME=0.18.0-SNAPSHOT
 
 SONATYPE_HOST=CENTRAL_PORTAL
 SONATYPE_AUTOMATIC_RELEASE=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "9.0.1"
+agp = "9.1.1"
 bouncy-castle = "1.78.1"
 cbor = "4.5.6"
 cose = "1.1.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -16,7 +16,7 @@
 
 #Wed Apr 30 10:24:47 EEST 2025
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Refer to [issue#133](https://github.com/eu-digital-identity-wallet/eudi-lib-android-wallet-document-manager/issues/133)
Closes #133 